### PR TITLE
[feature] Add multiversion initializer

### DIFF
--- a/.github/workflows/building_ci_cd.yaml
+++ b/.github/workflows/building_ci_cd.yaml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v3
       with:
-        python-version: '3.11.1'
+        python-version: '3.10'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/testing_ci_cd.yml
+++ b/.github/workflows/testing_ci_cd.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: '3.11.1'
+          python-version: '3.10'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Make sure to run after installation:
   pyenv update
 ```
 
-python >= 3.11.1
+python >= 3.10
 ```bash
   pyenv install 3.11.1
 ```

--- a/Pipfile
+++ b/Pipfile
@@ -2,7 +2,7 @@
 url = "https://pypi.org/simple"
 verify_ssl = true
 name = "pypi"
-python_version = "3.11"
+python_version = "3.10"
 
 [packages]
 pre-commit = "*"

--- a/README.md
+++ b/README.md
@@ -97,15 +97,16 @@ class Crud:
 main.py
 ```python
 from py_ocpi import get_application
-from py_ocpi.core.enums import RoleEnum
+from py_ocpi.core.enums import RoleEnum, ModuleID
 from py_ocpi.modules.versions.enums import VersionNumber
 
 from crud import Crud
 
 
 app = get_application(
-    version_numbers=[VersionNumber.v_2_2_1],
+    version_numbers=[VersionNumber.v_2_1_1, VersionNumber.v_2_2_1],
     roles=[RoleEnum.cpo],
+    modules=[ModuleID.locations],
     crud=Crud,
 )
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Python implementation of Open Charge Point Interface (OCPI) protocol based on fa
 
 ---
 
-Python >= 3.11.1
+Python >= 3.10
 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -92,24 +92,7 @@ class Crud:
 
 ```
 
-2) Implement all needed module adapters inside Adapter class.
-
-adapter.py
-```python
-from py_ocpi.modules.versions.enums import VersionNumber
-from py_ocpi.modules.locations.v_2_2_1.schemas import Location
-
-
-class Adapter:
-
-    @classmethod
-    def location_adapter(cls, data: dict, version: VersionNumber) -> Location:
-        """Return location."""
-        return Location(**data)
-
-```
-
-3) Initialize fastapi application
+2) Initialize fastapi application
 
 main.py
 ```python
@@ -117,7 +100,6 @@ from py_ocpi import get_application
 from py_ocpi.core.enums import RoleEnum
 from py_ocpi.modules.versions.enums import VersionNumber
 
-from adapter import Adapter
 from crud import Crud
 
 
@@ -125,12 +107,11 @@ app = get_application(
     version_numbers=[VersionNumber.v_2_2_1],
     roles=[RoleEnum.cpo],
     crud=Crud,
-    adapter=Adapter,
 )
 
 ```
 
-4) Run
+3) Run
 
 ```bash
   uvicorn main:app --reload
@@ -152,7 +133,9 @@ Example: `http://127.0.0.1:8000/ocpi/docs/`
 - [in progress] Add support for OCPI v2.1.1
   - What's done so far:
     - Add version, credentials and locations module;
-    - Add support for initializing v2.1.1 (It's possible to initialize only one version for one project); 
+    - Add support for initializing v2.1.1;
+    - It's now possible to initialize a few versions of ocpi for one project;
+    - Minimal required python version is 3.10;
 
 
 ## Related

--- a/py_ocpi/__init__.py
+++ b/py_ocpi/__init__.py
@@ -1,6 +1,6 @@
 """Python Implementation of OCPI"""
 
-__version__ = "2023.09.20"
+__version__ = "2023.09.22"
 
 from .core import enums, data_types
 from .main import get_application

--- a/py_ocpi/core/adapter.py
+++ b/py_ocpi/core/adapter.py
@@ -195,7 +195,7 @@ class BaseAdapter(Adapter):
     ):
         """Adapt the data to OCPI ChargingPreference schema"""
         return get_module_model(
-            class_name="ChargingPreference",
+            class_name="ChargingPreferences",
             module_name="sessions",
             version_name=version.name,
         )(**data)

--- a/py_ocpi/core/adapter.py
+++ b/py_ocpi/core/adapter.py
@@ -172,67 +172,107 @@ class BaseAdapter(Adapter):
         cls, data: dict, version: VersionNumber = VersionNumber.latest
     ):
         """Adapt the data to OCPI Location schema"""
-        return get_module_model("Location", version.name)(**data)
+        return get_module_model(
+            class_name="Location",
+            module_name="locations",
+            version_name=version.name,
+        )(**data)
 
     @classmethod
     def session_adapter(
         cls, data: dict, version: VersionNumber = VersionNumber.latest
     ):
         """Adapt the data to OCPI Session schema"""
-        return get_module_model("Session", version.name)(**data)
+        return get_module_model(
+            class_name="Session",
+            module_name="sessions",
+            version_name=version.name,
+        )(**data)
 
     @classmethod
     def charging_preference_adapter(
         cls, data: dict, version: VersionNumber = VersionNumber.latest
     ):
         """Adapt the data to OCPI ChargingPreference schema"""
-        return get_module_model("ChargingPreference", version.name)(**data)
+        return get_module_model(
+            class_name="ChargingPreference",
+            module_name="sessions",
+            version_name=version.name,
+        )(**data)
 
     @classmethod
     def credentials_adapter(
         cls, data: dict, version: VersionNumber = VersionNumber.latest
     ):
-        """Adapt the data to OCPI Credential schema"""
-        return get_module_model("Credential", version.name)(**data)
+        """Adapt the data to OCPI Credentials schema"""
+        return get_module_model(
+            class_name="Credentials",
+            module_name="credentials",
+            version_name=version.name,
+        )(**data)
 
     @classmethod
     def cdr_adapter(
         cls, data: dict, version: VersionNumber = VersionNumber.latest
     ):
-        """Adapt the data to OCPI CDR schema"""
-        return get_module_model("CDR", version.name)(**data)
+        """Adapt the data to OCPI Cdr schema"""
+        return get_module_model(
+            class_name="Cdr",
+            module_name="cdrs",
+            version_name=version.name,
+        )(**data)
 
     @classmethod
     def tariff_adapter(
         cls, data: dict, version: VersionNumber = VersionNumber.latest
     ):
         """Adapt the data to OCPI Tariff schema"""
-        return get_module_model("Tariff", version.name)(**data)
+        return get_module_model(
+            class_name="Tariff",
+            module_name="tariffs",
+            version_name=version.name,
+        )(**data)
 
     @classmethod
     def command_response_adapter(
         cls, data: dict, version: VersionNumber = VersionNumber.latest
     ):
         """Adapt the data to OCPI CommandResponse schema"""
-        return get_module_model("CommandResponse", version.name)(**data)
+        return get_module_model(
+            class_name="CommandResponse",
+            module_name="commands",
+            version_name=version.name,
+        )(**data)
 
     @classmethod
     def command_result_adapter(
         cls, data: dict, version: VersionNumber = VersionNumber.latest
     ):
         """Adapt the data to OCPI CommandResult schema"""
-        return get_module_model("CommandResult", version.name)(**data)
+        return get_module_model(
+            class_name="CommandResult",
+            module_name="commands",
+            version_name=version.name,
+        )(**data)
 
     @classmethod
     def token_adapter(
         cls, data: dict, version: VersionNumber = VersionNumber.latest
     ):
         """Adapt the data to OCPI Token schema"""
-        return get_module_model("Token", version.name)(**data)
+        return get_module_model(
+            class_name="Token",
+            module_name="tokens",
+            version_name=version.name,
+        )(**data)
 
     @classmethod
     def authorization_adapter(
         cls, data: dict, version: VersionNumber = VersionNumber.latest
     ):
         """Adapt the data to OCPI AuthorizationInfo schema"""
-        return get_module_model("AuthorizationInfo", version.name)(**data)
+        return get_module_model(
+            class_name="AuthorizationInfo",
+            module_name="tokens",
+            version_name=version.name,
+        )(**data)

--- a/py_ocpi/core/adapter.py
+++ b/py_ocpi/core/adapter.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 
+from py_ocpi.core.utils import get_module_model
 from py_ocpi.modules.versions.enums import VersionNumber
 
 
@@ -163,3 +164,75 @@ class Adapter(ABC):
             AuthorizationInfo: The object data in proper OCPI schema
         """
         pass
+
+
+class BaseAdapter(Adapter):
+    @classmethod
+    def location_adapter(
+        cls, data: dict, version: VersionNumber = VersionNumber.latest
+    ):
+        """Adapt the data to OCPI Location schema"""
+        return get_module_model("Location", version.name)(**data)
+
+    @classmethod
+    def session_adapter(
+        cls, data: dict, version: VersionNumber = VersionNumber.latest
+    ):
+        """Adapt the data to OCPI Session schema"""
+        return get_module_model("Session", version.name)(**data)
+
+    @classmethod
+    def charging_preference_adapter(
+        cls, data: dict, version: VersionNumber = VersionNumber.latest
+    ):
+        """Adapt the data to OCPI ChargingPreference schema"""
+        return get_module_model("ChargingPreference", version.name)(**data)
+
+    @classmethod
+    def credentials_adapter(
+        cls, data: dict, version: VersionNumber = VersionNumber.latest
+    ):
+        """Adapt the data to OCPI Credential schema"""
+        return get_module_model("Credential", version.name)(**data)
+
+    @classmethod
+    def cdr_adapter(
+        cls, data: dict, version: VersionNumber = VersionNumber.latest
+    ):
+        """Adapt the data to OCPI CDR schema"""
+        return get_module_model("CDR", version.name)(**data)
+
+    @classmethod
+    def tariff_adapter(
+        cls, data: dict, version: VersionNumber = VersionNumber.latest
+    ):
+        """Adapt the data to OCPI Tariff schema"""
+        return get_module_model("Tariff", version.name)(**data)
+
+    @classmethod
+    def command_response_adapter(
+        cls, data: dict, version: VersionNumber = VersionNumber.latest
+    ):
+        """Adapt the data to OCPI CommandResponse schema"""
+        return get_module_model("CommandResponse", version.name)(**data)
+
+    @classmethod
+    def command_result_adapter(
+        cls, data: dict, version: VersionNumber = VersionNumber.latest
+    ):
+        """Adapt the data to OCPI CommandResult schema"""
+        return get_module_model("CommandResult", version.name)(**data)
+
+    @classmethod
+    def token_adapter(
+        cls, data: dict, version: VersionNumber = VersionNumber.latest
+    ):
+        """Adapt the data to OCPI Token schema"""
+        return get_module_model("Token", version.name)(**data)
+
+    @classmethod
+    def authorization_adapter(
+        cls, data: dict, version: VersionNumber = VersionNumber.latest
+    ):
+        """Adapt the data to OCPI AuthorizationInfo schema"""
+        return get_module_model("AuthorizationInfo", version.name)(**data)

--- a/py_ocpi/core/dependencies.py
+++ b/py_ocpi/core/dependencies.py
@@ -34,6 +34,10 @@ def get_endpoints():
     return {}
 
 
+def get_modules():
+    return []
+
+
 def pagination_filters(
     date_from: datetime = Query(default=None),
     date_to: datetime = Query(default=None),

--- a/py_ocpi/core/utils.py
+++ b/py_ocpi/core/utils.py
@@ -82,10 +82,10 @@ def decode_string_base64(input: str) -> str:
     return input_bytes.decode("utf-8")
 
 
-def get_module_model(class_name, version_name: str) -> Any:
-    module_name = f"py_ocpi.modules.locations.{version_name}.schemas"
+def get_module_model(class_name, module_name: str, version_name: str) -> Any:
+    module_dir = f"py_ocpi.modules.{module_name}.{version_name}.schemas"
     try:
-        module = importlib.import_module(module_name)
+        module = importlib.import_module(module_dir)
         return getattr(module, class_name)
     except ImportError:
         raise NotImplementedError(

--- a/py_ocpi/core/utils.py
+++ b/py_ocpi/core/utils.py
@@ -1,6 +1,7 @@
+import importlib
 import urllib
 import base64
-from typing import Union
+from typing import Union, Any
 
 from fastapi import Response, Request
 from pydantic import BaseModel
@@ -79,3 +80,14 @@ def encode_string_base64(input: str) -> str:
 def decode_string_base64(input: str) -> str:
     input_bytes = base64.b64decode(bytes(input, "utf-8"))
     return input_bytes.decode("utf-8")
+
+
+def get_module_model(class_name, version_name: str) -> Any:
+    module_name = f"py_ocpi.modules.locations.{version_name}.schemas"
+    try:
+        module = importlib.import_module(module_name)
+        return getattr(module, class_name)
+    except ImportError:
+        raise NotImplementedError(
+            f"{class_name} schema for version {version_name} not found.",
+        )

--- a/py_ocpi/main.py
+++ b/py_ocpi/main.py
@@ -18,10 +18,11 @@ from py_ocpi.core.dependencies import (
     get_adapter,
     get_versions,
     get_endpoints,
+    get_modules,
 )
 from py_ocpi.core import status
 from py_ocpi.core.adapter import BaseAdapter
-from py_ocpi.core.enums import RoleEnum
+from py_ocpi.core.enums import RoleEnum, ModuleID
 from py_ocpi.core.config import settings
 from py_ocpi.core.data_types import URL
 from py_ocpi.core.schemas import OCPIResponse
@@ -57,6 +58,7 @@ def get_application(
     version_numbers: List[VersionNumber],
     roles: List[RoleEnum],
     crud: Any,
+    modules: List[ModuleID],
     adapter: Any = BaseAdapter,
     http_push: bool = False,
     websocket_push: bool = False,
@@ -119,20 +121,30 @@ def get_application(
         version_endpoints[version] = []
 
         if RoleEnum.cpo in roles:
-            _app.include_router(
-                mapped_version["cpo_router"],
-                prefix=f"/{settings.OCPI_PREFIX}/cpo/{version.value}",
-                tags=["CPO"],
-            )
-            version_endpoints[version] += ENDPOINTS[version][RoleEnum.cpo]
+            for module in modules:
+                cpo_router = mapped_version["cpo_router"].get(module)
+                if cpo_router:
+                    _app.include_router(
+                        cpo_router,
+                        prefix=f"/{settings.OCPI_PREFIX}/cpo/{version.value}",
+                        tags=[f"CPO {version}"],
+                    )
+                    version_endpoints[version] += ENDPOINTS[version][
+                        RoleEnum.cpo
+                    ]
 
         if RoleEnum.emsp in roles:
-            _app.include_router(
-                mapped_version["emsp_router"],
-                prefix=f"/{settings.OCPI_PREFIX}/emsp/{version.value}",
-                tags=["EMSP"],
-            )
-            version_endpoints[version] += ENDPOINTS[version][RoleEnum.emsp]
+            for module in modules:
+                emsp_router = mapped_version["emsp_router"].get(module)
+                if emsp_router:
+                    _app.include_router(
+                        emsp_router,
+                        prefix=f"/{settings.OCPI_PREFIX}/emsp/{version.value}",
+                        tags=[f"EMSP {version}"],
+                    )
+                    version_endpoints[version] += ENDPOINTS[version][
+                        RoleEnum.emsp
+                    ]
 
     def override_get_crud():
         return crud
@@ -153,5 +165,10 @@ def get_application(
         return version_endpoints
 
     _app.dependency_overrides[get_endpoints] = override_get_endpoints
+
+    def override_get_modules():
+        return modules
+
+    _app.dependency_overrides[get_modules] = override_get_modules()
 
     return _app

--- a/py_ocpi/modules/credentials/v_2_1_1/api/cpo.py
+++ b/py_ocpi/modules/credentials/v_2_1_1/api/cpo.py
@@ -40,7 +40,7 @@ async def get_credentials(
         version=VersionNumber.v_2_1_1,
     )
     return OCPIResponse(
-        data=adapter.credentials_adapter(data).dict(),
+        data=adapter.credentials_adapter(data, VersionNumber.v_2_1_1).dict(),
         **status.OCPI_1000_GENERIC_SUCESS_CODE,
     )
 
@@ -106,7 +106,9 @@ async def post_credentials(
                 )
 
                 return OCPIResponse(
-                    data=adapter.credentials_adapter(new_credentials).dict(),
+                    data=adapter.credentials_adapter(
+                        new_credentials, VersionNumber.v_2_1_1
+                    ).dict(),
                     **status.OCPI_1000_GENERIC_SUCESS_CODE,
                 )
 
@@ -179,7 +181,9 @@ async def update_credentials(
                 )
 
                 return OCPIResponse(
-                    data=adapter.credentials_adapter(new_credentials).dict(),
+                    data=adapter.credentials_adapter(
+                        new_credentials, VersionNumber.v_2_1_1
+                    ).dict(),
                     **status.OCPI_1000_GENERIC_SUCESS_CODE,
                 )
 

--- a/py_ocpi/modules/credentials/v_2_1_1/api/emsp.py
+++ b/py_ocpi/modules/credentials/v_2_1_1/api/emsp.py
@@ -40,7 +40,7 @@ async def get_credentials(
         version=VersionNumber.v_2_1_1,
     )
     return OCPIResponse(
-        data=adapter.credentials_adapter(data).dict(),
+        data=adapter.credentials_adapter(data, VersionNumber.v_2_1_1).dict(),
         **status.OCPI_1000_GENERIC_SUCESS_CODE,
     )
 
@@ -106,7 +106,9 @@ async def post_credentials(
                 )
 
                 return OCPIResponse(
-                    data=adapter.credentials_adapter(new_credentials).dict(),
+                    data=adapter.credentials_adapter(
+                        new_credentials, VersionNumber.v_2_1_1
+                    ).dict(),
                     **status.OCPI_1000_GENERIC_SUCESS_CODE,
                 )
 
@@ -179,7 +181,9 @@ async def update_credentials(
                 )
 
                 return OCPIResponse(
-                    data=adapter.credentials_adapter(new_credentials).dict(),
+                    data=adapter.credentials_adapter(
+                        new_credentials, VersionNumber.v_2_1_1
+                    ).dict(),
                     **status.OCPI_1000_GENERIC_SUCESS_CODE,
                 )
 

--- a/py_ocpi/modules/locations/v_2_1_1/api/cpo.py
+++ b/py_ocpi/modules/locations/v_2_1_1/api/cpo.py
@@ -37,7 +37,9 @@ async def get_locations(
 
     locations = []
     for data in data_list:
-        locations.append(adapter.location_adapter(data).dict())
+        locations.append(
+            adapter.location_adapter(data, VersionNumber.v_2_1_1).dict()
+        )
     return OCPIResponse(
         data=locations,
         **status.OCPI_1000_GENERIC_SUCESS_CODE,
@@ -61,7 +63,7 @@ async def get_location(
         version=VersionNumber.v_2_1_1,
     )
     return OCPIResponse(
-        data=[adapter.location_adapter(data).dict()],
+        data=[adapter.location_adapter(data, VersionNumber.v_2_1_1).dict()],
         **status.OCPI_1000_GENERIC_SUCESS_CODE,
     )
 
@@ -83,7 +85,7 @@ async def get_evse(
         auth_token=auth_token,
         version=VersionNumber.v_2_1_1,
     )
-    location = adapter.location_adapter(data)
+    location = adapter.location_adapter(data, VersionNumber.v_2_1_1)
     for evse in location.evses:
         if evse.uid == evse_uid:
             return OCPIResponse(
@@ -112,7 +114,7 @@ async def get_connector(
         auth_token=auth_token,
         version=VersionNumber.v_2_1_1,
     )
-    location = adapter.location_adapter(data)
+    location = adapter.location_adapter(data, VersionNumber.v_2_1_1)
     for evse in location.evses:
         if evse.uid == evse_uid:
             for connector in evse.connectors:

--- a/py_ocpi/modules/locations/v_2_1_1/api/emsp.py
+++ b/py_ocpi/modules/locations/v_2_1_1/api/emsp.py
@@ -51,7 +51,7 @@ async def get_location(
         version=VersionNumber.v_2_1_1,
     )
     return OCPIResponse(
-        data=[adapter.location_adapter(data).dict()],
+        data=[adapter.location_adapter(data, VersionNumber.v_2_1_1).dict()],
         **status.OCPI_1000_GENERIC_SUCESS_CODE,
     )
 
@@ -80,7 +80,7 @@ async def get_evse(
         party_id=party_id,
         version=VersionNumber.v_2_1_1,
     )
-    location = adapter.location_adapter(data)
+    location = adapter.location_adapter(data, VersionNumber.v_2_1_1)
     for evse in location.evses:
         if evse.uid == evse_uid:
             return OCPIResponse(
@@ -114,7 +114,7 @@ async def get_connector(
         party_id=party_id,
         version=VersionNumber.v_2_1_1,
     )
-    location = adapter.location_adapter(data)
+    location = adapter.location_adapter(data, VersionNumber.v_2_1_1)
     for evse in location.evses:
         if evse.uid == evse_uid:
             for connector in evse.connectors:
@@ -171,7 +171,7 @@ async def add_or_update_location(
         )
 
     return OCPIResponse(
-        data=[adapter.location_adapter(data).dict()],
+        data=[adapter.location_adapter(data, VersionNumber.v_2_1_1).dict()],
         **status.OCPI_1000_GENERIC_SUCESS_CODE,
     )
 
@@ -201,7 +201,7 @@ async def add_or_update_evse(
         party_id=party_id,
         version=VersionNumber.v_2_1_1,
     )
-    old_location = adapter.location_adapter(old_data)
+    old_location = adapter.location_adapter(old_data, VersionNumber.v_2_1_1)
     new_location = copy.deepcopy(old_location)
 
     for old_evse in old_location.evses:
@@ -254,7 +254,7 @@ async def add_or_update_connector(
         party_id=party_id,
         version=VersionNumber.v_2_1_1,
     )
-    old_location = adapter.location_adapter(old_data)
+    old_location = adapter.location_adapter(old_data, VersionNumber.v_2_1_1)
     new_location = copy.deepcopy(old_location)
 
     response_data = []
@@ -312,7 +312,7 @@ async def partial_update_location(
         party_id=party_id,
         version=VersionNumber.v_2_1_1,
     )
-    old_location = adapter.location_adapter(old_data)
+    old_location = adapter.location_adapter(old_data, VersionNumber.v_2_1_1)
     new_location = copy.deepcopy(old_location)
 
     partially_update_attributes(
@@ -331,7 +331,7 @@ async def partial_update_location(
     )
 
     return OCPIResponse(
-        data=[adapter.location_adapter(data).dict()],
+        data=[adapter.location_adapter(data, VersionNumber.v_2_1_1).dict()],
         **status.OCPI_1000_GENERIC_SUCESS_CODE,
     )
 
@@ -361,7 +361,7 @@ async def partial_update_evse(
         party_id=party_id,
         version=VersionNumber.v_2_1_1,
     )
-    old_location = adapter.location_adapter(old_data)
+    old_location = adapter.location_adapter(old_data, VersionNumber.v_2_1_1)
     new_location = copy.deepcopy(old_location)
 
     response_data = []
@@ -420,7 +420,7 @@ async def partial_update_connector(
         party_id=party_id,
         version=VersionNumber.v_2_1_1,
     )
-    old_location = adapter.location_adapter(old_data)
+    old_location = adapter.location_adapter(old_data, VersionNumber.v_2_1_1)
 
     for old_evse in old_location.evses:
         if old_evse.uid == evse_uid:

--- a/py_ocpi/routers/v_2_1_1/cpo.py
+++ b/py_ocpi/routers/v_2_1_1/cpo.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter
+from py_ocpi.core.enums import ModuleID
 
 from py_ocpi.modules.credentials.v_2_1_1.api import (
     cpo_router as credentials_cpo_2_1_1_router,
@@ -8,7 +8,7 @@ from py_ocpi.modules.locations.v_2_1_1.api import (
 )
 
 
-router = APIRouter()
-
-router.include_router(locations_cpo_2_1_1_router)
-router.include_router(credentials_cpo_2_1_1_router)
+router = {
+    ModuleID.locations: locations_cpo_2_1_1_router,
+    ModuleID.credentials_and_registration: credentials_cpo_2_1_1_router,
+}

--- a/py_ocpi/routers/v_2_1_1/emsp.py
+++ b/py_ocpi/routers/v_2_1_1/emsp.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter
+from py_ocpi.core.enums import ModuleID
 
 from py_ocpi.modules.credentials.v_2_1_1.api import (
     emsp_router as credentials_emsp_2_1_1_router,
@@ -8,7 +8,7 @@ from py_ocpi.modules.locations.v_2_1_1.api import (
 )
 
 
-router = APIRouter()
-
-router.include_router(locations_emsp_2_1_1_router)
-router.include_router(credentials_emsp_2_1_1_router)
+router = {
+    ModuleID.locations: locations_emsp_2_1_1_router,
+    ModuleID.credentials_and_registration: credentials_emsp_2_1_1_router,
+}

--- a/py_ocpi/routers/v_2_2_1/cpo.py
+++ b/py_ocpi/routers/v_2_2_1/cpo.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter
+from py_ocpi.core.enums import ModuleID
 
 from py_ocpi.modules.credentials.v_2_2_1.api import (
     cpo_router as credentials_cpo_2_2_1_router,
@@ -18,14 +18,17 @@ from py_ocpi.modules.tariffs.v_2_2_1.api import (
 from py_ocpi.modules.tokens.v_2_2_1.api import (
     cpo_router as tokens_cpo_2_2_1_router,
 )
-from py_ocpi.modules.cdrs.v_2_2_1.api import cpo_router as cdrs_cpo_2_2_1_router
+from py_ocpi.modules.cdrs.v_2_2_1.api import (
+    cpo_router as cdrs_cpo_2_2_1_router,
+)
 
 
-router = APIRouter()
-router.include_router(locations_cpo_2_2_1_router)
-router.include_router(credentials_cpo_2_2_1_router)
-router.include_router(sessions_cpo_2_2_1_router)
-router.include_router(commands_cpo_2_2_1_router)
-router.include_router(tariffs_cpo_2_2_1_router)
-router.include_router(tokens_cpo_2_2_1_router)
-router.include_router(cdrs_cpo_2_2_1_router)
+router = {
+    ModuleID.locations: locations_cpo_2_2_1_router,
+    ModuleID.credentials_and_registration: credentials_cpo_2_2_1_router,
+    ModuleID.sessions: sessions_cpo_2_2_1_router,
+    ModuleID.commands: commands_cpo_2_2_1_router,
+    ModuleID.tariffs: tariffs_cpo_2_2_1_router,
+    ModuleID.tokens: tokens_cpo_2_2_1_router,
+    ModuleID.cdrs: cdrs_cpo_2_2_1_router,
+}

--- a/py_ocpi/routers/v_2_2_1/emsp.py
+++ b/py_ocpi/routers/v_2_2_1/emsp.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter
+from py_ocpi.core.enums import ModuleID
 
 from py_ocpi.modules.credentials.v_2_2_1.api import (
     emsp_router as credentials_emsp_2_2_1_router,
@@ -23,11 +23,12 @@ from py_ocpi.modules.tokens.v_2_2_1.api import (
 )
 
 
-router = APIRouter()
-router.include_router(locations_emsp_2_2_1_router)
-router.include_router(credentials_emsp_2_2_1_router)
-router.include_router(sessions_emsp_2_2_1_router)
-router.include_router(cdrs_emsp_2_2_1_router)
-router.include_router(tariffs_emsp_2_2_1_router)
-router.include_router(commands_emsp_2_2_1_router)
-router.include_router(tokens_emsp_2_2_1_router)
+router = {
+    ModuleID.locations: locations_emsp_2_2_1_router,
+    ModuleID.credentials_and_registration: credentials_emsp_2_2_1_router,
+    ModuleID.sessions: sessions_emsp_2_2_1_router,
+    ModuleID.commands: commands_emsp_2_2_1_router,
+    ModuleID.tariffs: tariffs_emsp_2_2_1_router,
+    ModuleID.tokens: tokens_emsp_2_2_1_router,
+    ModuleID.cdrs: cdrs_emsp_2_2_1_router,
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ exclude = '''
 [project]
 name = "extrawest_ocpi"
 description = "Python implementation of Open Charge Point Interface (OCPI) protocol based on fastapi."
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 readme = "README.md"
 license = {text = "MIT"}
 dynamic = ["version"]
@@ -60,7 +60,7 @@ count = true
 exclude = "tests/*"
 
 [tool.mypy]
-python_version = "3.11"
+python_version = "3.10"
 ignore_missing_imports = "True"
 plugins = ["pydantic.mypy", ]
 exclude = ["venv", "tests"]

--- a/tests/test_dependency_injection.py
+++ b/tests/test_dependency_injection.py
@@ -7,17 +7,41 @@ from py_ocpi.core import enums
 from py_ocpi.modules.versions.enums import VersionNumber
 
 
-def test_inject_dependency():
+def test_inject_dependency_v_2_2_1():
     crud = AsyncMock()
     crud.list.return_value = [], 0, True
 
     adapter = MagicMock()
 
     app = get_application(
-        [VersionNumber.v_2_2_1], [enums.RoleEnum.cpo], crud, adapter
+        version_numbers=[VersionNumber.v_2_2_1],
+        roles=[enums.RoleEnum.cpo],
+        crud=crud,
+        adapter=adapter,
+        modules=[enums.ModuleID.locations],
     )
 
     client = TestClient(app)
     client.get("/ocpi/cpo/2.2.1/locations")
+
+    crud.list.assert_awaited_once()
+
+
+def test_inject_dependency_v_2_1_1():
+    crud = AsyncMock()
+    crud.list.return_value = [], 0, True
+
+    adapter = MagicMock()
+
+    app = get_application(
+        version_numbers=[VersionNumber.v_2_1_1],
+        roles=[enums.RoleEnum.cpo],
+        crud=crud,
+        adapter=adapter,
+        modules=[enums.ModuleID.locations],
+    )
+
+    client = TestClient(app)
+    client.get("/ocpi/cpo/2.1.1/locations")
 
     crud.list.assert_awaited_once()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -11,7 +11,11 @@ def test_get_application():
         ...
 
     app = get_application(
-        [VersionNumber.v_2_2_1], [enums.RoleEnum.cpo], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_2_1],
+        roles=[enums.RoleEnum.cpo],
+        crud=Crud,
+        modules=[],
+        adapter=Adapter,
     )
 
     assert app.url_path_for("get_versions") == "/ocpi/versions"

--- a/tests/test_modules/test_v_2_1_1/test_credentials.py
+++ b/tests/test_modules/test_v_2_1_1/test_credentials.py
@@ -83,7 +83,10 @@ class Adapter:
 
 def test_cpo_get_credentials_v_2_1_1():
     app = get_application(
-        [VersionNumber.v_2_1_1], [enums.RoleEnum.cpo], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_1_1],
+        roles=[enums.RoleEnum.cpo],
+        crud=Crud,
+        modules=[enums.ModuleID.credentials_and_registration],
     )
     token = str(uuid4())
     header = {"Authorization": f"Token {token}"}
@@ -113,7 +116,10 @@ async def test_cpo_post_credentials_v_2_1_1(async_client):
             return {}
 
     app_1 = get_application(
-        [VersionNumber.v_2_1_1], [enums.RoleEnum.emsp], MockCrud, Adapter
+        version_numbers=[VersionNumber.v_2_1_1],
+        roles=[enums.RoleEnum.emsp],
+        crud=MockCrud,
+        modules=[enums.ModuleID.credentials_and_registration],
     )
 
     def override_get_versions():
@@ -131,7 +137,10 @@ async def test_cpo_post_credentials_v_2_1_1(async_client):
     async_client.return_value = AsyncClient(app=app_1, base_url="http://test")
 
     app_2 = get_application(
-        [VersionNumber.v_2_1_1], [enums.RoleEnum.cpo], MockCrud, Adapter
+        version_numbers=[VersionNumber.v_2_1_1],
+        roles=[enums.RoleEnum.cpo],
+        crud=MockCrud,
+        modules=[enums.ModuleID.credentials_and_registration],
     )
 
     async with AsyncClient(app=app_2, base_url="http://test") as client:

--- a/tests/test_modules/test_v_2_1_1/test_credentials.py
+++ b/tests/test_modules/test_v_2_1_1/test_credentials.py
@@ -73,14 +73,6 @@ class Crud:
         return None
 
 
-class Adapter:
-    @classmethod
-    def credentials_adapter(
-        cls, data, version: VersionNumber = VersionNumber.v_2_1_1
-    ) -> Credentials:
-        return Credentials(**data)
-
-
 def test_cpo_get_credentials_v_2_1_1():
     app = get_application(
         version_numbers=[VersionNumber.v_2_1_1],

--- a/tests/test_modules/test_v_2_1_1/test_credentials.py
+++ b/tests/test_modules/test_v_2_1_1/test_credentials.py
@@ -12,7 +12,6 @@ from py_ocpi.core import enums
 from py_ocpi.core.data_types import URL
 from py_ocpi.core.config import settings
 from py_ocpi.core.dependencies import get_versions
-from py_ocpi.modules.credentials.v_2_1_1.schemas import Credentials
 from py_ocpi.modules.versions.enums import VersionNumber
 from py_ocpi.modules.versions.schemas import Version
 

--- a/tests/test_modules/test_v_2_1_1/test_locations.py
+++ b/tests/test_modules/test_v_2_1_1/test_locations.py
@@ -5,7 +5,6 @@ from fastapi.testclient import TestClient
 from py_ocpi.main import get_application
 from py_ocpi.core import enums
 from py_ocpi.core.config import settings
-from py_ocpi.modules.locations.v_2_1_1.schemas import Location
 from py_ocpi.modules.versions.enums import VersionNumber
 
 

--- a/tests/test_modules/test_v_2_1_1/test_locations.py
+++ b/tests/test_modules/test_v_2_1_1/test_locations.py
@@ -209,14 +209,6 @@ class Crud:
         return LOCATIONS, 1, True
 
 
-class Adapter:
-    @classmethod
-    def location_adapter(
-        cls, data, version: VersionNumber = VersionNumber.v_2_1_1
-    ) -> Location:
-        return Location(**data)
-
-
 def test_cpo_get_locations_v_2_1_1():
     app = get_application(
         version_numbers=[VersionNumber.v_2_1_1],

--- a/tests/test_modules/test_v_2_1_1/test_locations.py
+++ b/tests/test_modules/test_v_2_1_1/test_locations.py
@@ -219,7 +219,10 @@ class Adapter:
 
 def test_cpo_get_locations_v_2_1_1():
     app = get_application(
-        [VersionNumber.v_2_1_1], [enums.RoleEnum.cpo], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_1_1],
+        roles=[enums.RoleEnum.cpo],
+        crud=Crud,
+        modules=[enums.ModuleID.locations],
     )
 
     client = TestClient(app)
@@ -232,7 +235,10 @@ def test_cpo_get_locations_v_2_1_1():
 
 def test_cpo_get_location_v_2_1_1():
     app = get_application(
-        [VersionNumber.v_2_1_1], [enums.RoleEnum.cpo], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_1_1],
+        roles=[enums.RoleEnum.cpo],
+        crud=Crud,
+        modules=[enums.ModuleID.locations],
     )
 
     client = TestClient(app)
@@ -244,7 +250,10 @@ def test_cpo_get_location_v_2_1_1():
 
 def test_cpo_get_evse_v_2_1_1():
     app = get_application(
-        [VersionNumber.v_2_1_1], [enums.RoleEnum.cpo], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_1_1],
+        roles=[enums.RoleEnum.cpo],
+        crud=Crud,
+        modules=[enums.ModuleID.locations],
     )
 
     client = TestClient(app)
@@ -259,7 +268,10 @@ def test_cpo_get_evse_v_2_1_1():
 
 def test_cpo_get_connector_v_2_1_1():
     app = get_application(
-        [VersionNumber.v_2_1_1], [enums.RoleEnum.cpo], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_1_1],
+        roles=[enums.RoleEnum.cpo],
+        crud=Crud,
+        modules=[enums.ModuleID.locations],
     )
 
     client = TestClient(app)
@@ -278,7 +290,10 @@ def test_cpo_get_connector_v_2_1_1():
 
 def test_emsp_get_location_v_2_1_1():
     app = get_application(
-        [VersionNumber.v_2_1_1], [enums.RoleEnum.emsp], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_1_1],
+        roles=[enums.RoleEnum.emsp],
+        crud=Crud,
+        modules=[enums.ModuleID.locations],
     )
 
     client = TestClient(app)
@@ -293,7 +308,10 @@ def test_emsp_get_location_v_2_1_1():
 
 def test_emsp_get_evse_v_2_1_1():
     app = get_application(
-        [VersionNumber.v_2_1_1], [enums.RoleEnum.emsp], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_1_1],
+        roles=[enums.RoleEnum.emsp],
+        crud=Crud,
+        modules=[enums.ModuleID.locations],
     )
 
     client = TestClient(app)
@@ -309,7 +327,10 @@ def test_emsp_get_evse_v_2_1_1():
 
 def test_emsp_get_connector_v_2_1_1():
     app = get_application(
-        [VersionNumber.v_2_1_1], [enums.RoleEnum.emsp], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_1_1],
+        roles=[enums.RoleEnum.emsp],
+        crud=Crud,
+        modules=[enums.ModuleID.locations],
     )
 
     client = TestClient(app)
@@ -329,7 +350,10 @@ def test_emsp_get_connector_v_2_1_1():
 
 def test_emsp_add_location_v_2_1_1():
     app = get_application(
-        [VersionNumber.v_2_1_1], [enums.RoleEnum.emsp], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_1_1],
+        roles=[enums.RoleEnum.emsp],
+        crud=Crud,
+        modules=[enums.ModuleID.locations],
     )
 
     client = TestClient(app)
@@ -345,7 +369,10 @@ def test_emsp_add_location_v_2_1_1():
 
 def test_emsp_add_evse_v_2_1_1():
     app = get_application(
-        [VersionNumber.v_2_1_1], [enums.RoleEnum.emsp], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_1_1],
+        roles=[enums.RoleEnum.emsp],
+        crud=Crud,
+        modules=[enums.ModuleID.locations],
     )
 
     client = TestClient(app)
@@ -362,7 +389,10 @@ def test_emsp_add_evse_v_2_1_1():
 
 def test_emsp_add_connector_v_2_1_1():
     app = get_application(
-        [VersionNumber.v_2_1_1], [enums.RoleEnum.emsp], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_1_1],
+        roles=[enums.RoleEnum.emsp],
+        crud=Crud,
+        modules=[enums.ModuleID.locations],
     )
 
     client = TestClient(app)
@@ -383,7 +413,10 @@ def test_emsp_add_connector_v_2_1_1():
 
 def test_emsp_patch_location_v_2_1_1():
     app = get_application(
-        [VersionNumber.v_2_1_1], [enums.RoleEnum.emsp], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_1_1],
+        roles=[enums.RoleEnum.emsp],
+        crud=Crud,
+        modules=[enums.ModuleID.locations],
     )
 
     patch_data = {"id": str(uuid4())}
@@ -400,7 +433,10 @@ def test_emsp_patch_location_v_2_1_1():
 
 def test_emsp_patch_evse_v_2_1_1():
     app = get_application(
-        [VersionNumber.v_2_1_1], [enums.RoleEnum.emsp], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_1_1],
+        roles=[enums.RoleEnum.emsp],
+        crud=Crud,
+        modules=[enums.ModuleID.locations],
     )
 
     patch_data = {"uid": str(uuid4())}
@@ -418,7 +454,10 @@ def test_emsp_patch_evse_v_2_1_1():
 
 def test_emsp_patch_connector_v_2_1_1():
     app = get_application(
-        [VersionNumber.v_2_1_1], [enums.RoleEnum.emsp], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_1_1],
+        roles=[enums.RoleEnum.emsp],
+        crud=Crud,
+        modules=[enums.ModuleID.locations],
     )
 
     patch_data = {"id": str(uuid4())}

--- a/tests/test_modules/test_v_2_1_1/test_versions.py
+++ b/tests/test_modules/test_v_2_1_1/test_versions.py
@@ -12,7 +12,10 @@ from py_ocpi.core.enums import ModuleID, RoleEnum, Action
 
 def test_get_versions():
     app = get_application(
-        [VersionNumber.v_2_1_1], [enums.RoleEnum.cpo], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_1_1],
+        roles=[enums.RoleEnum.cpo],
+        crud=Crud,
+        modules=[],
     )
 
     client = TestClient(app)
@@ -42,7 +45,10 @@ def test_get_versions_v_2_1_1():
             return {}
 
     app = get_application(
-        [VersionNumber.v_2_1_1], [enums.RoleEnum.cpo], MockCrud, Adapter
+        version_numbers=[VersionNumber.v_2_1_1],
+        roles=[enums.RoleEnum.cpo],
+        crud=MockCrud,
+        modules=[],
     )
 
     client = TestClient(app)
@@ -71,7 +77,10 @@ def test_get_versions_v_2_1_1_requires_auth():
             return None
 
     app = get_application(
-        [VersionNumber.v_2_1_1], [enums.RoleEnum.cpo], MockCrud, Adapter
+        version_numbers=[VersionNumber.v_2_1_1],
+        roles=[enums.RoleEnum.cpo],
+        crud=MockCrud,
+        modules=[],
     )
 
     client = TestClient(app)

--- a/tests/test_modules/test_v_2_1_1/test_versions.py
+++ b/tests/test_modules/test_v_2_1_1/test_versions.py
@@ -5,7 +5,6 @@ from fastapi.testclient import TestClient
 from py_ocpi.main import get_application
 from py_ocpi.core import enums
 from py_ocpi.core.crud import Crud
-from py_ocpi.core.adapter import Adapter
 from py_ocpi.modules.versions.enums import VersionNumber
 from py_ocpi.core.enums import ModuleID, RoleEnum, Action
 

--- a/tests/test_modules/test_v_2_2_1/test_cdrs.py
+++ b/tests/test_modules/test_v_2_2_1/test_cdrs.py
@@ -91,17 +91,12 @@ class Crud:
         return data
 
 
-class Adapter:
-    @classmethod
-    def cdr_adapter(
-        cls, data, version: VersionNumber = VersionNumber.latest
-    ) -> Cdr:
-        return Cdr(**data)
-
-
 def test_cpo_get_cdrs_v_2_2_1():
     app = get_application(
-        [VersionNumber.v_2_2_1], [enums.RoleEnum.cpo], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_2_1],
+        roles=[enums.RoleEnum.cpo],
+        crud=Crud,
+        modules=[enums.ModuleID.cdrs],
     )
 
     client = TestClient(app)
@@ -114,7 +109,10 @@ def test_cpo_get_cdrs_v_2_2_1():
 
 def test_emsp_get_cdr_v_2_2_1():
     app = get_application(
-        [VersionNumber.v_2_2_1], [enums.RoleEnum.emsp], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_2_1],
+        roles=[enums.RoleEnum.emsp],
+        crud=Crud,
+        modules=[enums.ModuleID.cdrs],
     )
 
     client = TestClient(app)
@@ -126,7 +124,10 @@ def test_emsp_get_cdr_v_2_2_1():
 
 def test_emsp_add_cdr_v_2_2_1():
     app = get_application(
-        [VersionNumber.v_2_2_1], [enums.RoleEnum.emsp], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_2_1],
+        roles=[enums.RoleEnum.emsp],
+        crud=Crud,
+        modules=[enums.ModuleID.cdrs],
     )
 
     data = CDRS[0]

--- a/tests/test_modules/test_v_2_2_1/test_commands.py
+++ b/tests/test_modules/test_v_2_2_1/test_commands.py
@@ -12,10 +12,6 @@ from py_ocpi.modules.commands.v_2_2_1.enums import (
     CommandResponseType,
     CommandResultType,
 )
-from py_ocpi.modules.commands.v_2_2_1.schemas import (
-    CommandResponse,
-    CommandResult,
-)
 from py_ocpi.modules.versions.enums import VersionNumber
 
 COMMAND_RESPONSE = {"result": CommandResponseType.accepted, "timeout": 30}
@@ -60,23 +56,12 @@ class Crud:
         ...
 
 
-class Adapter:
-    @classmethod
-    def command_response_adapter(
-        cls, data, version: VersionNumber = VersionNumber.latest
-    ):
-        return CommandResponse(**data)
-
-    @classmethod
-    def command_result_adapter(
-        cls, data, version: VersionNumber = VersionNumber.latest
-    ):
-        return CommandResult(**data)
-
-
 def test_cpo_receive_command_start_session_v_2_2_1():
     app = get_application(
-        [VersionNumber.v_2_2_1], [enums.RoleEnum.cpo], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_2_1],
+        roles=[enums.RoleEnum.cpo],
+        crud=Crud,
+        modules=[enums.ModuleID.commands, enums.ModuleID.sessions],
     )
 
     data = {
@@ -107,7 +92,10 @@ def test_cpo_receive_command_start_session_v_2_2_1():
 
 def test_cpo_receive_command_stop_session_v_2_2_1():
     app = get_application(
-        [VersionNumber.v_2_2_1], [enums.RoleEnum.cpo], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_2_1],
+        roles=[enums.RoleEnum.cpo],
+        crud=Crud,
+        modules=[enums.ModuleID.commands, enums.ModuleID.sessions],
     )
 
     data = {
@@ -127,7 +115,10 @@ def test_cpo_receive_command_stop_session_v_2_2_1():
 
 def test_cpo_receive_command_reserve_now_v_2_2_1():
     app = get_application(
-        [VersionNumber.v_2_2_1], [enums.RoleEnum.cpo], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_2_1],
+        roles=[enums.RoleEnum.cpo],
+        crud=Crud,
+        modules=[enums.ModuleID.commands],
     )
 
     data = {
@@ -174,7 +165,10 @@ def test_cpo_receive_command_reserve_now_unknown_location_v_2_2_1():
     Crud.get = get
 
     app = get_application(
-        [VersionNumber.v_2_2_1], [enums.RoleEnum.cpo], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_2_1],
+        roles=[enums.RoleEnum.cpo],
+        crud=Crud,
+        modules=[enums.ModuleID.commands],
     )
 
     data = {
@@ -211,7 +205,10 @@ def test_cpo_receive_command_reserve_now_unknown_location_v_2_2_1():
 
 def test_emsp_receive_command_result_v_2_2_1():
     app = get_application(
-        [VersionNumber.v_2_2_1], [enums.RoleEnum.emsp], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_2_1],
+        roles=[enums.RoleEnum.emsp],
+        crud=Crud,
+        modules=[enums.ModuleID.commands],
     )
 
     client = TestClient(app)

--- a/tests/test_modules/test_v_2_2_1/test_credentials.py
+++ b/tests/test_modules/test_v_2_2_1/test_credentials.py
@@ -13,9 +13,6 @@ from py_ocpi.core.data_types import URL
 from py_ocpi.core.config import settings
 from py_ocpi.core.dependencies import get_versions
 from py_ocpi.core.utils import encode_string_base64
-from py_ocpi.modules.credentials.v_2_2_1.schemas import Credentials
-from py_ocpi.modules.tokens.v_2_2_1.enums import AllowedType
-from py_ocpi.modules.tokens.v_2_2_1.schemas import AuthorizationInfo, Token
 from py_ocpi.modules.versions.enums import VersionNumber
 from py_ocpi.modules.versions.schemas import Version
 
@@ -86,17 +83,12 @@ class Crud:
         return None
 
 
-class Adapter:
-    @classmethod
-    def credentials_adapter(
-        cls, data, version: VersionNumber = VersionNumber.latest
-    ) -> Credentials:
-        return Credentials(**data)
-
-
 def test_cpo_get_credentials_v_2_2_1():
     app = get_application(
-        [VersionNumber.v_2_2_1], [enums.RoleEnum.cpo], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_2_1],
+        roles=[enums.RoleEnum.cpo],
+        crud=Crud,
+        modules=[enums.ModuleID.credentials_and_registration],
     )
     token = str(uuid4())
     header = {"Authorization": f"Token {encode_string_base64(token)}"}
@@ -126,7 +118,10 @@ async def test_cpo_post_credentials_v_2_2_1(async_client):
             return {}
 
     app_1 = get_application(
-        [VersionNumber.v_2_2_1], [enums.RoleEnum.emsp], MockCrud, Adapter
+        version_numbers=[VersionNumber.v_2_2_1],
+        roles=[enums.RoleEnum.emsp],
+        crud=MockCrud,
+        modules=[enums.ModuleID.credentials_and_registration],
     )
 
     def override_get_versions():
@@ -144,7 +139,10 @@ async def test_cpo_post_credentials_v_2_2_1(async_client):
     async_client.return_value = AsyncClient(app=app_1, base_url="http://test")
 
     app_2 = get_application(
-        [VersionNumber.v_2_2_1], [enums.RoleEnum.cpo], MockCrud, Adapter
+        version_numbers=[VersionNumber.v_2_2_1],
+        roles=[enums.RoleEnum.cpo],
+        crud=MockCrud,
+        modules=[enums.ModuleID.credentials_and_registration],
     )
 
     async with AsyncClient(app=app_2, base_url="http://test") as client:

--- a/tests/test_modules/test_v_2_2_1/test_locations.py
+++ b/tests/test_modules/test_v_2_2_1/test_locations.py
@@ -5,7 +5,6 @@ from fastapi.testclient import TestClient
 from py_ocpi.main import get_application
 from py_ocpi.core import enums
 from py_ocpi.core.config import settings
-from py_ocpi.modules.locations.v_2_2_1.schemas import Location
 from py_ocpi.modules.versions.enums import VersionNumber
 
 
@@ -225,17 +224,12 @@ class Crud:
         return LOCATIONS, 1, True
 
 
-class Adapter:
-    @classmethod
-    def location_adapter(
-        cls, data, version: VersionNumber = VersionNumber.latest
-    ) -> Location:
-        return Location(**data)
-
-
 def test_cpo_get_locations_v_2_2_1():
     app = get_application(
-        [VersionNumber.v_2_2_1], [enums.RoleEnum.cpo], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_2_1],
+        roles=[enums.RoleEnum.cpo],
+        crud=Crud,
+        modules=[enums.ModuleID.locations],
     )
 
     client = TestClient(app)
@@ -248,7 +242,10 @@ def test_cpo_get_locations_v_2_2_1():
 
 def test_cpo_get_location_v_2_2_1():
     app = get_application(
-        [VersionNumber.v_2_2_1], [enums.RoleEnum.cpo], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_2_1],
+        roles=[enums.RoleEnum.cpo],
+        crud=Crud,
+        modules=[enums.ModuleID.locations],
     )
 
     client = TestClient(app)
@@ -260,7 +257,10 @@ def test_cpo_get_location_v_2_2_1():
 
 def test_cpo_get_evse_v_2_2_1():
     app = get_application(
-        [VersionNumber.v_2_2_1], [enums.RoleEnum.cpo], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_2_1],
+        roles=[enums.RoleEnum.cpo],
+        crud=Crud,
+        modules=[enums.ModuleID.locations],
     )
 
     client = TestClient(app)
@@ -275,7 +275,10 @@ def test_cpo_get_evse_v_2_2_1():
 
 def test_cpo_get_connector_v_2_2_1():
     app = get_application(
-        [VersionNumber.v_2_2_1], [enums.RoleEnum.cpo], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_2_1],
+        roles=[enums.RoleEnum.cpo],
+        crud=Crud,
+        modules=[enums.ModuleID.locations],
     )
 
     client = TestClient(app)
@@ -294,7 +297,10 @@ def test_cpo_get_connector_v_2_2_1():
 
 def test_emsp_get_location_v_2_2_1():
     app = get_application(
-        [VersionNumber.v_2_2_1], [enums.RoleEnum.emsp], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_2_1],
+        roles=[enums.RoleEnum.emsp],
+        crud=Crud,
+        modules=[enums.ModuleID.locations],
     )
 
     client = TestClient(app)
@@ -309,7 +315,10 @@ def test_emsp_get_location_v_2_2_1():
 
 def test_emsp_get_evse_v_2_2_1():
     app = get_application(
-        [VersionNumber.v_2_2_1], [enums.RoleEnum.emsp], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_2_1],
+        roles=[enums.RoleEnum.emsp],
+        crud=Crud,
+        modules=[enums.ModuleID.locations],
     )
 
     client = TestClient(app)
@@ -325,7 +334,10 @@ def test_emsp_get_evse_v_2_2_1():
 
 def test_emsp_get_connector_v_2_2_1():
     app = get_application(
-        [VersionNumber.v_2_2_1], [enums.RoleEnum.emsp], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_2_1],
+        roles=[enums.RoleEnum.emsp],
+        crud=Crud,
+        modules=[enums.ModuleID.locations],
     )
 
     client = TestClient(app)
@@ -345,7 +357,10 @@ def test_emsp_get_connector_v_2_2_1():
 
 def test_emsp_add_location_v_2_2_1():
     app = get_application(
-        [VersionNumber.v_2_2_1], [enums.RoleEnum.emsp], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_2_1],
+        roles=[enums.RoleEnum.emsp],
+        crud=Crud,
+        modules=[enums.ModuleID.locations],
     )
 
     client = TestClient(app)
@@ -361,7 +376,10 @@ def test_emsp_add_location_v_2_2_1():
 
 def test_emsp_add_evse_v_2_2_1():
     app = get_application(
-        [VersionNumber.v_2_2_1], [enums.RoleEnum.emsp], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_2_1],
+        roles=[enums.RoleEnum.emsp],
+        crud=Crud,
+        modules=[enums.ModuleID.locations],
     )
 
     client = TestClient(app)
@@ -378,7 +396,10 @@ def test_emsp_add_evse_v_2_2_1():
 
 def test_emsp_add_connector_v_2_2_1():
     app = get_application(
-        [VersionNumber.v_2_2_1], [enums.RoleEnum.emsp], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_2_1],
+        roles=[enums.RoleEnum.emsp],
+        crud=Crud,
+        modules=[enums.ModuleID.locations],
     )
 
     client = TestClient(app)
@@ -399,7 +420,10 @@ def test_emsp_add_connector_v_2_2_1():
 
 def test_emsp_patch_location_v_2_2_1():
     app = get_application(
-        [VersionNumber.v_2_2_1], [enums.RoleEnum.emsp], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_2_1],
+        roles=[enums.RoleEnum.emsp],
+        crud=Crud,
+        modules=[enums.ModuleID.locations],
     )
 
     patch_data = {"id": str(uuid4())}
@@ -416,7 +440,10 @@ def test_emsp_patch_location_v_2_2_1():
 
 def test_emsp_patch_evse_v_2_2_1():
     app = get_application(
-        [VersionNumber.v_2_2_1], [enums.RoleEnum.emsp], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_2_1],
+        roles=[enums.RoleEnum.emsp],
+        crud=Crud,
+        modules=[enums.ModuleID.locations],
     )
 
     patch_data = {"uid": str(uuid4())}
@@ -434,7 +461,10 @@ def test_emsp_patch_evse_v_2_2_1():
 
 def test_emsp_patch_connector_v_2_2_1():
     app = get_application(
-        [VersionNumber.v_2_2_1], [enums.RoleEnum.emsp], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_2_1],
+        roles=[enums.RoleEnum.emsp],
+        crud=Crud,
+        modules=[enums.ModuleID.locations],
     )
 
     patch_data = {"id": str(uuid4())}

--- a/tests/test_modules/test_v_2_2_1/test_sessions.py
+++ b/tests/test_modules/test_v_2_2_1/test_sessions.py
@@ -7,10 +7,6 @@ from py_ocpi.core import enums
 from py_ocpi.core.config import settings
 from py_ocpi.modules.cdrs.v_2_2_1.schemas import TokenType
 from py_ocpi.modules.cdrs.v_2_2_1.enums import AuthMethod, CdrDimensionType
-from py_ocpi.modules.sessions.v_2_2_1.schemas import (
-    Session,
-    ChargingPreferences,
-)
 from py_ocpi.modules.sessions.v_2_2_1.enums import SessionStatus, ProfileType
 from py_ocpi.modules.versions.enums import VersionNumber
 
@@ -95,23 +91,12 @@ class Crud:
         return SESSIONS, 1, True
 
 
-class Adapter:
-    @classmethod
-    def session_adapter(
-        cls, data, version: VersionNumber = VersionNumber.latest
-    ) -> Session:
-        return Session(**data)
-
-    @classmethod
-    def charging_preference_adapter(
-        cls, data, version: VersionNumber = VersionNumber.latest
-    ) -> Session:
-        return ChargingPreferences(**data)
-
-
 def test_cpo_get_sessions_v_2_2_1():
     app = get_application(
-        [VersionNumber.v_2_2_1], [enums.RoleEnum.cpo], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_2_1],
+        roles=[enums.RoleEnum.cpo],
+        crud=Crud,
+        modules=[enums.ModuleID.sessions],
     )
 
     client = TestClient(app)
@@ -124,7 +109,10 @@ def test_cpo_get_sessions_v_2_2_1():
 
 def test_cpo_set_charging_preference_v_2_2_1():
     app = get_application(
-        [VersionNumber.v_2_2_1], [enums.RoleEnum.cpo], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_2_1],
+        roles=[enums.RoleEnum.cpo],
+        crud=Crud,
+        modules=[enums.ModuleID.sessions],
     )
 
     client = TestClient(app)
@@ -143,7 +131,10 @@ def test_cpo_set_charging_preference_v_2_2_1():
 
 def test_emsp_get_session_v_2_2_1():
     app = get_application(
-        [VersionNumber.v_2_2_1], [enums.RoleEnum.emsp], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_2_1],
+        roles=[enums.RoleEnum.emsp],
+        crud=Crud,
+        modules=[enums.ModuleID.sessions],
     )
 
     client = TestClient(app)
@@ -158,7 +149,10 @@ def test_emsp_get_session_v_2_2_1():
 
 def test_emsp_add_session_v_2_2_1():
     app = get_application(
-        [VersionNumber.v_2_2_1], [enums.RoleEnum.emsp], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_2_1],
+        roles=[enums.RoleEnum.emsp],
+        crud=Crud,
+        modules=[enums.ModuleID.sessions],
     )
 
     client = TestClient(app)
@@ -174,7 +168,10 @@ def test_emsp_add_session_v_2_2_1():
 
 def test_emsp_patch_session_v_2_2_1():
     app = get_application(
-        [VersionNumber.v_2_2_1], [enums.RoleEnum.emsp], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_2_1],
+        roles=[enums.RoleEnum.emsp],
+        crud=Crud,
+        modules=[enums.ModuleID.sessions],
     )
 
     patch_data = {"id": str(uuid4())}

--- a/tests/test_modules/test_v_2_2_1/test_tariffs.py
+++ b/tests/test_modules/test_v_2_2_1/test_tariffs.py
@@ -5,7 +5,6 @@ from fastapi.testclient import TestClient
 from py_ocpi.main import get_application
 from py_ocpi.core import enums
 from py_ocpi.core.config import settings
-from py_ocpi.modules.tariffs.v_2_2_1.schemas import Tariff
 from py_ocpi.modules.versions.enums import VersionNumber
 
 TARIFFS = [
@@ -75,17 +74,12 @@ class Crud:
         return TARIFFS, 1, True
 
 
-class Adapter:
-    @classmethod
-    def tariff_adapter(
-        cls, data, version: VersionNumber = VersionNumber.latest
-    ) -> Tariff:
-        return Tariff(**data)
-
-
 def test_cpo_get_tariffs_v_2_2_1():
     app = get_application(
-        [VersionNumber.v_2_2_1], [enums.RoleEnum.cpo], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_2_1],
+        roles=[enums.RoleEnum.cpo],
+        crud=Crud,
+        modules=[enums.ModuleID.tariffs],
     )
 
     client = TestClient(app)
@@ -98,7 +92,10 @@ def test_cpo_get_tariffs_v_2_2_1():
 
 def test_emsp_get_tariff_v_2_2_1():
     app = get_application(
-        [VersionNumber.v_2_2_1], [enums.RoleEnum.emsp], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_2_1],
+        roles=[enums.RoleEnum.emsp],
+        crud=Crud,
+        modules=[enums.ModuleID.tariffs],
     )
 
     client = TestClient(app)
@@ -113,7 +110,10 @@ def test_emsp_get_tariff_v_2_2_1():
 
 def test_emsp_add_tariff_v_2_2_1():
     app = get_application(
-        [VersionNumber.v_2_2_1], [enums.RoleEnum.emsp], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_2_1],
+        roles=[enums.RoleEnum.emsp],
+        crud=Crud,
+        modules=[enums.ModuleID.tariffs],
     )
 
     client = TestClient(app)
@@ -129,7 +129,10 @@ def test_emsp_add_tariff_v_2_2_1():
 
 def test_emsp_delete_tariff_v_2_2_1():
     app = get_application(
-        [VersionNumber.v_2_2_1], [enums.RoleEnum.emsp], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_2_1],
+        roles=[enums.RoleEnum.emsp],
+        crud=Crud,
+        modules=[enums.ModuleID.tariffs],
     )
 
     client = TestClient(app)

--- a/tests/test_modules/test_v_2_2_1/test_tokens.py
+++ b/tests/test_modules/test_v_2_2_1/test_tokens.py
@@ -100,23 +100,12 @@ class Crud:
         return TOKENS[0]
 
 
-class Adapter:
-    @classmethod
-    def token_adapter(
-        cls, data, version: VersionNumber = VersionNumber.latest
-    ) -> Token:
-        return Token(**dict(data))
-
-    @classmethod
-    def authorization_adapter(
-        cls, data: dict, version: VersionNumber = VersionNumber.latest
-    ):
-        return AuthorizationInfo(**data)
-
-
 def test_cpo_get_token_v_2_2_1():
     app = get_application(
-        [VersionNumber.v_2_2_1], [enums.RoleEnum.cpo], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_2_1],
+        roles=[enums.RoleEnum.cpo],
+        crud=Crud,
+        modules=[enums.ModuleID.tokens],
     )
 
     client = TestClient(app)
@@ -132,7 +121,10 @@ def test_cpo_get_token_v_2_2_1():
 
 def test_cpo_add_token_v_2_2_1():
     app = get_application(
-        [VersionNumber.v_2_2_1], [enums.RoleEnum.cpo], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_2_1],
+        roles=[enums.RoleEnum.cpo],
+        crud=Crud,
+        modules=[enums.ModuleID.tokens],
     )
 
     client = TestClient(app)
@@ -149,7 +141,10 @@ def test_cpo_add_token_v_2_2_1():
 
 def test_cpo_update_token_v_2_2_1():
     app = get_application(
-        [VersionNumber.v_2_2_1], [enums.RoleEnum.cpo], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_2_1],
+        roles=[enums.RoleEnum.cpo],
+        crud=Crud,
+        modules=[enums.ModuleID.tokens],
     )
 
     client = TestClient(app)
@@ -169,7 +164,10 @@ def test_cpo_update_token_v_2_2_1():
 
 def test_emsp_get_tokens_v_2_2_1():
     app = get_application(
-        [VersionNumber.v_2_2_1], [enums.RoleEnum.emsp], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_2_1],
+        roles=[enums.RoleEnum.emsp],
+        crud=Crud,
+        modules=[enums.ModuleID.tokens],
     )
 
     client = TestClient(app)
@@ -182,7 +180,10 @@ def test_emsp_get_tokens_v_2_2_1():
 
 def test_emsp_authorize_token_success_v_2_2_1():
     app = get_application(
-        [VersionNumber.v_2_2_1], [enums.RoleEnum.emsp], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_2_1],
+        roles=[enums.RoleEnum.emsp],
+        crud=Crud,
+        modules=[enums.ModuleID.tokens],
     )
 
     client = TestClient(app)
@@ -211,7 +212,10 @@ def test_emsp_authorize_token_unknown_v_2_2_1():
     Crud.get = get
 
     app = get_application(
-        [VersionNumber.v_2_2_1], [enums.RoleEnum.emsp], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_2_1],
+        roles=[enums.RoleEnum.emsp],
+        crud=Crud,
+        modules=[enums.ModuleID.tokens],
     )
 
     client = TestClient(app)
@@ -243,7 +247,10 @@ def test_emsp_authorize_token_missing_info_v_2_2_1():
     Crud.do = do
 
     app = get_application(
-        [VersionNumber.v_2_2_1], [enums.RoleEnum.emsp], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_2_1],
+        roles=[enums.RoleEnum.emsp],
+        crud=Crud,
+        modules=[enums.ModuleID.tokens],
     )
 
     client = TestClient(app)

--- a/tests/test_modules/test_v_2_2_1/test_versions.py
+++ b/tests/test_modules/test_v_2_2_1/test_versions.py
@@ -5,14 +5,16 @@ from fastapi.testclient import TestClient
 from py_ocpi.main import get_application
 from py_ocpi.core import enums
 from py_ocpi.core.crud import Crud
-from py_ocpi.core.adapter import Adapter
 from py_ocpi.modules.versions.enums import VersionNumber
 from py_ocpi.core.enums import ModuleID, RoleEnum, Action
 
 
 def test_get_versions():
     app = get_application(
-        [VersionNumber.v_2_2_1], [enums.RoleEnum.cpo], Crud, Adapter
+        version_numbers=[VersionNumber.v_2_2_1],
+        roles=[enums.RoleEnum.cpo],
+        crud=Crud,
+        modules=[],
     )
 
     client = TestClient(app)
@@ -42,7 +44,10 @@ def test_get_versions_v_2_2_1():
             return {}
 
     app = get_application(
-        [VersionNumber.v_2_2_1], [enums.RoleEnum.cpo], MockCrud, Adapter
+        version_numbers=[VersionNumber.v_2_2_1],
+        roles=[enums.RoleEnum.cpo],
+        crud=MockCrud,
+        modules=[],
     )
 
     client = TestClient(app)
@@ -71,7 +76,10 @@ def test_get_versions_v_2_2_1_requires_auth():
             return None
 
     app = get_application(
-        [VersionNumber.v_2_2_1], [enums.RoleEnum.cpo], MockCrud, Adapter
+        version_numbers=[VersionNumber.v_2_2_1],
+        roles=[enums.RoleEnum.cpo],
+        crud=MockCrud,
+        modules=[],
     )
 
     client = TestClient(app)

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -7,18 +7,44 @@ from py_ocpi.core import enums
 from py_ocpi.modules.versions.enums import VersionNumber
 
 
-def test_inject_dependency():
+def test_inject_dependency_v_2_2_1():
     crud = AsyncMock()
     crud.list.return_value = [], 0, True
 
     adapter = MagicMock()
 
     app = get_application(
-        [VersionNumber.v_2_2_1], [enums.RoleEnum.cpo], crud, adapter
+        version_numbers=[VersionNumber.v_2_2_1],
+        roles=[enums.RoleEnum.cpo],
+        crud=crud,
+        adapter=adapter,
+        modules=[enums.ModuleID.locations],
     )
 
     client = TestClient(app)
     response = client.get("/ocpi/cpo/2.2.1/locations")
+
+    assert response.headers.get("X-Total-Count") == "0"
+    assert response.headers.get("X-Limit") == "50"
+    assert response.headers.get("Link") == ""
+
+
+def test_inject_dependency_v_2_1_1():
+    crud = AsyncMock()
+    crud.list.return_value = [], 0, True
+
+    adapter = MagicMock()
+
+    app = get_application(
+        version_numbers=[VersionNumber.v_2_1_1],
+        roles=[enums.RoleEnum.cpo],
+        crud=crud,
+        adapter=adapter,
+        modules=[enums.ModuleID.locations],
+    )
+
+    client = TestClient(app)
+    response = client.get("/ocpi/cpo/2.1.1/locations")
 
     assert response.headers.get("X-Total-Count") == "0"
     assert response.headers.get("X-Limit") == "50"

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -197,10 +197,11 @@ def test_push(async_client):
     adapter.location_adapter.return_value = Location(**LOCATIONS[0])
 
     app = get_application(
-        [VersionNumber.v_2_2_1],
-        [enums.RoleEnum.cpo],
-        crud,
-        adapter,
+        version_numbers=[VersionNumber.v_2_2_1],
+        roles=[enums.RoleEnum.cpo],
+        crud=crud,
+        adapter=adapter,
+        modules=[],
         http_push=True,
     )
 


### PR DESCRIPTION
- It's now possible to initialize a few versions of ocpi for one project;
- Minimal required python version is 3.10;
- You can choose what modules you want to enable on app initializing