### PR TITLE
[bugfix] Hide unspecified endpoints

### DIFF
--- a/py_ocpi/core/endpoints/v_2_1_1/cpo.py
+++ b/py_ocpi/core/endpoints/v_2_1_1/cpo.py
@@ -25,7 +25,7 @@ LOCATIONS = Endpoint(
 )
 
 
-ENDPOINTS_LIST = [
-    CREDENTIALS_AND_REGISTRATION,
-    LOCATIONS,
-]
+ENDPOINTS_LIST = {
+    ModuleID.credentials_and_registration: CREDENTIALS_AND_REGISTRATION,
+    ModuleID.locations: LOCATIONS,
+}

--- a/py_ocpi/core/endpoints/v_2_1_1/emsp.py
+++ b/py_ocpi/core/endpoints/v_2_1_1/emsp.py
@@ -24,7 +24,7 @@ LOCATIONS = Endpoint(
     ),
 )
 
-ENDPOINTS_LIST = [
-    CREDENTIALS_AND_REGISTRATION,
-    LOCATIONS,
-]
+ENDPOINTS_LIST = {
+    ModuleID.credentials_and_registration: CREDENTIALS_AND_REGISTRATION,
+    ModuleID.locations: LOCATIONS,
+}

--- a/py_ocpi/core/endpoints/v_2_2_1/cpo.py
+++ b/py_ocpi/core/endpoints/v_2_2_1/cpo.py
@@ -63,11 +63,11 @@ TOKENS = Endpoint(
     ),
 )
 
-ENDPOINTS_LIST = [
-    CREDENTIALS_AND_REGISTRATION,
-    LOCATIONS,
-    SESSIONS,
-    CDRS,
-    TARIFFS,
-    TOKENS,
-]
+ENDPOINTS_LIST = {
+    ModuleID.credentials_and_registration: CREDENTIALS_AND_REGISTRATION,
+    ModuleID.locations: LOCATIONS,
+    ModuleID.sessions: SESSIONS,
+    ModuleID.cdrs: CDRS,
+    ModuleID.tariffs: TARIFFS,
+    ModuleID.tokens: TOKENS,
+}

--- a/py_ocpi/core/endpoints/v_2_2_1/emsp.py
+++ b/py_ocpi/core/endpoints/v_2_2_1/emsp.py
@@ -72,12 +72,12 @@ TOKENS = Endpoint(
     ),
 )
 
-ENDPOINTS_LIST = [
-    CREDENTIALS_AND_REGISTRATION,
-    LOCATIONS,
-    SESSIONS,
-    CDRS,
-    TARIFFS,
-    COMMANDS,
-    TOKENS,
-]
+ENDPOINTS_LIST = {
+    ModuleID.credentials_and_registration: CREDENTIALS_AND_REGISTRATION,
+    ModuleID.locations: LOCATIONS,
+    ModuleID.sessions: SESSIONS,
+    ModuleID.cdrs: CDRS,
+    ModuleID.tariffs: TARIFFS,
+    ModuleID.commands: COMMANDS,
+    ModuleID.tokens: TOKENS,
+}

--- a/py_ocpi/main.py
+++ b/py_ocpi/main.py
@@ -129,8 +129,9 @@ def get_application(
                         prefix=f"/{settings.OCPI_PREFIX}/cpo/{version.value}",
                         tags=[f"CPO {version}"],
                     )
-                    endpoint = ENDPOINTS[version][RoleEnum.cpo][module]
-                    version_endpoints[version].append(endpoint)
+                    endpoint = ENDPOINTS[version][RoleEnum.cpo].get(module)
+                    if endpoint:
+                        version_endpoints[version].append(endpoint)
 
         if RoleEnum.emsp in roles:
             for module in modules:
@@ -141,8 +142,9 @@ def get_application(
                         prefix=f"/{settings.OCPI_PREFIX}/emsp/{version.value}",
                         tags=[f"EMSP {version}"],
                     )
-                    endpoint = ENDPOINTS[version][RoleEnum.emsp][module]
-                    version_endpoints[version].append(endpoint)
+                    endpoint = ENDPOINTS[version][RoleEnum.emsp].get(module)
+                    if endpoint:
+                        version_endpoints[version].append(endpoint)
 
     def override_get_crud():
         return crud

--- a/py_ocpi/main.py
+++ b/py_ocpi/main.py
@@ -127,7 +127,7 @@ def get_application(
                     _app.include_router(
                         cpo_router,
                         prefix=f"/{settings.OCPI_PREFIX}/cpo/{version.value}",
-                        tags=[f"CPO {version}"],
+                        tags=[f"CPO {version.value}"],
                     )
                     endpoint = ENDPOINTS[version][RoleEnum.cpo].get(module)
                     if endpoint:
@@ -140,7 +140,7 @@ def get_application(
                     _app.include_router(
                         emsp_router,
                         prefix=f"/{settings.OCPI_PREFIX}/emsp/{version.value}",
-                        tags=[f"EMSP {version}"],
+                        tags=[f"EMSP {version.value}"],
                     )
                     endpoint = ENDPOINTS[version][RoleEnum.emsp].get(module)
                     if endpoint:

--- a/py_ocpi/main.py
+++ b/py_ocpi/main.py
@@ -129,9 +129,8 @@ def get_application(
                         prefix=f"/{settings.OCPI_PREFIX}/cpo/{version.value}",
                         tags=[f"CPO {version}"],
                     )
-                    version_endpoints[version] += ENDPOINTS[version][
-                        RoleEnum.cpo
-                    ]
+                    endpoint = ENDPOINTS[version][RoleEnum.cpo][module]
+                    version_endpoints[version].append(endpoint)
 
         if RoleEnum.emsp in roles:
             for module in modules:
@@ -142,9 +141,8 @@ def get_application(
                         prefix=f"/{settings.OCPI_PREFIX}/emsp/{version.value}",
                         tags=[f"EMSP {version}"],
                     )
-                    version_endpoints[version] += ENDPOINTS[version][
-                        RoleEnum.emsp
-                    ]
+                    endpoint = ENDPOINTS[version][RoleEnum.emsp][module]
+                    version_endpoints[version].append(endpoint)
 
     def override_get_crud():
         return crud

--- a/tests/test_modules/mocks/async_client.py
+++ b/tests/test_modules/mocks/async_client.py
@@ -1,6 +1,6 @@
 from py_ocpi.core.dependencies import get_versions
 from py_ocpi.core.endpoints import ENDPOINTS
-from py_ocpi.core.enums import RoleEnum
+from py_ocpi.core.enums import RoleEnum, ModuleID
 from py_ocpi.modules.versions.enums import VersionNumber
 from py_ocpi.modules.versions.v_2_2_1.schemas import VersionDetail
 
@@ -8,7 +8,11 @@ fake_endpoints_data = {
     "data": [
         VersionDetail(
             version=VersionNumber.v_2_2_1,
-            endpoints=ENDPOINTS[VersionNumber.v_2_2_1][RoleEnum.cpo],
+            endpoints=[
+                ENDPOINTS[VersionNumber.v_2_2_1][RoleEnum.cpo][
+                    ModuleID.locations
+                ]
+            ],
         ).dict(),
     ],
 }


### PR DESCRIPTION
- Hide endpoints in GET `/ocpi/<version_numver>/details`, because it returns all endpoints bypassing filtering rule. 