### PR TITLE
[hotfix] Model typos

### DIFF
--- a/py_ocpi/__init__.py
+++ b/py_ocpi/__init__.py
@@ -1,6 +1,6 @@
 """Python Implementation of OCPI"""
 
-__version__ = "2025.5.22"
+__version__ = "2025.6.4"
 
 from .core import enums, data_types
 from .main import get_application

--- a/py_ocpi/core/data_types.py
+++ b/py_ocpi/core/data_types.py
@@ -222,8 +222,6 @@ class Price(dict):
             raise TypeError("dictionary required")
         if "excl_vat" not in v:
             raise TypeError('property "excl_vat" required')
-        if "incl_vat" not in v:
-            raise TypeError('property "incl_vat" required')
         return cls(v)
 
     def __repr__(self):

--- a/py_ocpi/modules/cdrs/v_2_2_1/schemas.py
+++ b/py_ocpi/modules/cdrs/v_2_2_1/schemas.py
@@ -21,7 +21,7 @@ class SignedValue(BaseModel):
 
     nature: CiString(32)  # type: ignore
     plain_data: String(512)  # type: ignore
-    singed_data: String(5000)  # type: ignore
+    signed_data: String(5000)  # type: ignore
 
 
 class SignedData(BaseModel):
@@ -32,7 +32,7 @@ class SignedData(BaseModel):
     encoding_method: CiString(36)  # type: ignore
     encoding_method_version: Optional[int]
     public_key: Optional[String(512)]  # type: ignore
-    signed_value: List[SignedValue]
+    signed_values: List[SignedValue]
     url: Optional[String(512)]  # type: ignore
 
 

--- a/py_ocpi/modules/sessions/v_2_1_1/schemas.py
+++ b/py_ocpi/modules/sessions/v_2_1_1/schemas.py
@@ -1,7 +1,7 @@
 from typing import List, Optional
 from pydantic import BaseModel
 
-from py_ocpi.core.data_types import Number, Price, String, DateTime
+from py_ocpi.core.data_types import Number, String, DateTime
 from py_ocpi.modules.cdrs.v_2_1_1.enums import AuthMethod
 from py_ocpi.modules.cdrs.v_2_1_1.schemas import ChargingPeriod
 from py_ocpi.modules.locations.v_2_1_1.schemas import Location
@@ -23,7 +23,7 @@ class Session(BaseModel):
     meter_id: Optional[String(255)]  # type: ignore
     currency: String(3)  # type: ignore
     charging_periods: List[ChargingPeriod] = []
-    total_cost: Optional[Price]
+    total_cost: Optional[Number]
     status: SessionStatus
     last_updated: DateTime
 
@@ -39,6 +39,6 @@ class SessionPartialUpdate(BaseModel):
     meter_id: Optional[String(255)]  # type: ignore
     currency: Optional[String(3)]  # type: ignore
     charging_periods: Optional[List[ChargingPeriod]]
-    total_cost: Optional[Price]
+    total_cost: Optional[Number]
     status: Optional[SessionStatus]
     last_updated: Optional[DateTime]


### PR DESCRIPTION
1. FIX: v2.2.1 CDR model typos
2. FIX: v2.1.1 Session models proper tying of the total_cost
3. FIX: Remove incl_vat validation from Price model since it's optional field in v2.2.1 documentation