### PR TITLE
[hotfix] Parametrize case insensitive string preference

### DIFF
--- a/py_ocpi/__init__.py
+++ b/py_ocpi/__init__.py
@@ -1,6 +1,6 @@
 """Python Implementation of OCPI"""
 
-__version__ = "2025.6.4"
+__version__ = "2025.6.25"
 
 from .core import enums, data_types
 from .main import get_application

--- a/py_ocpi/core/config.py
+++ b/py_ocpi/core/config.py
@@ -19,6 +19,7 @@ class Settings(BaseSettings):
     COMMAND_AWAIT_TIME: int = 5
     GET_ACTIVE_PROFILE_AWAIT_TIME: int = 5
     TRAILING_SLASH: bool = True
+    CI_STRING_LOWERCASE_PREFERENCE: bool = True
 
     @classmethod
     @validator("BACKEND_CORS_ORIGINS", pre=True)

--- a/py_ocpi/core/data_types.py
+++ b/py_ocpi/core/data_types.py
@@ -6,6 +6,8 @@ from datetime import datetime, timezone
 from typing import Type
 from pydantic.fields import ModelField
 
+from .config import settings
+
 
 class StringBase(str):
     """
@@ -78,7 +80,11 @@ class CiStringBase(str):
             raise ValueError(
                 f"{field.name} length must be lower or equal to {cls.max_length}"
             )
-        return cls(v.lower())
+
+        if settings.CI_STRING_LOWERCASE_PREFERENCE:
+            return cls(v.lower())
+
+        return cls(v.upper())
 
     def __repr__(self):
         return f"CiString({super().__repr__()})"


### PR DESCRIPTION
1. Enrich settings with boolean parameter defining whether the case insensitive string should be treated as lowercase or uppercase strings